### PR TITLE
[Merged by Bors] - fix: use crate version for user agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ target/
 
 **/*.ipkg
 
-log.txt
-
 hub/**
+
+# Development
+log.txt
+development-config.yml

--- a/crates/http-sink/src/config.rs
+++ b/crates/http-sink/src/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use fluvio_connector_common::connector;
 use url::Url;
 
-const DEFAULT_USER_AGENT: &str = "fluvio/http-sink 0.1.0";
+const DEFAULT_USER_AGENT: &str = concat!("fluvio/http-sink ", env!("CARGO_PKG_VERSION"));
 const DEFAULT_HTTP_METHOD: &str = "POST";
 const DEFAULT_HTTP_HEADERS: [&str; 1] = ["Content-Type: text/html"];
 

--- a/tests/integration-sends-data-via-post.bats
+++ b/tests/integration-sends-data-via-post.bats
@@ -15,7 +15,7 @@ setup() {
     cp ./tests/integration-sends-data-via-post.yaml $FILE
 
     CONNECTOR=${UUID}-sends-data
-    VERSION=$(cat ./crates/http-sink/Connector.toml | grep "^version = " | cut -d"\"" -f2)
+    export VERSION=$(cat ./crates/http-sink/Connector.toml | grep "^version = " | cut -d"\"" -f2)
     IPKG_NAME="http-sink-$VERSION.ipkg"
     fluvio topic create $TOPIC
 
@@ -47,5 +47,9 @@ teardown() {
 
     echo "Contains California on Logger File"
     cat ./$LOGGER_FILENAME | grep "California"
+    assert_success
+
+    echo "Contains User Agent with current version"
+    cat ./$LOGGER_FILENAME | grep "user_agent: \"fluvio/http-sink $VERSION\""
     assert_success
 }

--- a/tests/integration-sends-data-via-post.bats
+++ b/tests/integration-sends-data-via-post.bats
@@ -48,6 +48,18 @@ teardown() {
     echo "Contains California on Logger File"
     cat ./$LOGGER_FILENAME | grep "California"
     assert_success
+}
+
+@test "sends-user-agent-with-current-version" {
+    echo "Starting consumer on topic $TOPIC"
+    echo "Using connector $CONNECTOR"
+    sleep 45
+
+    echo "Produce \"North Carolina\" on $TOPIC"
+    echo "North Carolina" | fluvio produce $TOPIC
+
+    echo "Sleep to ensure record is processed"
+    sleep 25
 
     echo "Contains User Agent with current version"
     cat ./$LOGGER_FILENAME | grep "user_agent: \"fluvio/http-sink $VERSION\""

--- a/tests/integration-sends-data-via-post.bats
+++ b/tests/integration-sends-data-via-post.bats
@@ -30,7 +30,7 @@ setup() {
 
 teardown() {
     fluvio topic delete $TOPIC
-    cdk deploy shutdown $CONNECTOR
+    cdk deploy shutdown --name $CONNECTOR
     kill $MOCK_PID
 }
 


### PR DESCRIPTION
Uses the version from Cargo.toml to determine the default `User-Agent` version